### PR TITLE
Add USER-level SysVar.setString / SysVar.createString JSON-RPC methods

### DIFF
--- a/WebUI/www/api/methods.conf
+++ b/WebUI/www/api/methods.conf
@@ -893,12 +893,24 @@ SysVar.createEnum {
   INFO {Erzeugt eine Systemvariable vom Typ enum}
   ARGUMENTS {_session_id_ name valList internal chnID}
 }
+SysVar.createString {
+  LEVEL USER
+  SCRIPT_FILE sysvar/createstring.tcl
+  INFO {Erzeugt eine Systemvariable vom Typ String}
+  ARGUMENTS {_session_id_ name init_val internal chnID}
+}
 
 SysVar.setEnum {
   LEVEL USER
   SCRIPT_FILE sysvar/setenum.tcl
   INFO {Setzt den Wert einer Systemvariable vom Typ enum}
   ARGUMENTS {_session_id_ name valueList}
+}
+SysVar.setString {
+  LEVEL USER
+  SCRIPT_FILE sysvar/setstring.tcl
+  INFO {Setzt den Wert einer Systemvariable vom Typ String}
+  ARGUMENTS {_session_id_ name value}
 }
 
 SysVar.deleteSysVarByName {

--- a/WebUI/www/api/methods/sysvar/createstring.tcl
+++ b/WebUI/www/api/methods/sysvar/createstring.tcl
@@ -1,0 +1,40 @@
+##
+# SysVar.createString
+# Erzeugt eine Systemvariable vom Typ String.
+#
+# Parameter:
+#   name: [string] Name der betreffenden Systemvariablen.
+#   init_val: [string] Initialer Wert
+#   internal: [integer]  Variable sichtbar / Variable intern
+#   chnID: [integer] ID des Kanals, an dem die Variable gebunden werden soll. Wenn an kein Kanal gebunden werden soll, ist -1 zu uebergeben
+#   Rueckgabewert: [string]
+#   Objekt der Systemvariablen mit Name, ID, Wert.
+##
+
+set script {
+
+  if (chnID != -1) {
+   object channel = dom.GetObject(chnID);
+  }
+
+  object oSysVars = dom.GetObject( ID_SYSTEM_VARIABLES );
+  object sv = dom.CreateObject(OT_VARDP);
+
+  sv.Name(name);
+  sv.ValueType( ivtString );
+  sv.ValueSubType( istChar8859 );
+  sv.State(init_val);
+
+  sv.Internal(internal);
+
+  if (channel) {
+    sv.Channel(chnID);
+    channel.DPs().Add(sv.ID());
+  }
+
+  oSysVars.Add(sv.ID());
+
+  Write("{'name':'"#sv.Name()#"','id':'"#sv.ID()#"','value':'"#sv.Value()#"' }");
+}
+
+jsonrpc_response [hmscript $script args]

--- a/WebUI/www/api/methods/sysvar/setstring.tcl
+++ b/WebUI/www/api/methods/sysvar/setstring.tcl
@@ -1,0 +1,27 @@
+ ##
+ # SysVar.setString
+ # Setzt den Wert einer Systemvariable vom Typ String
+ #
+ # Parameter:
+ #   name: [string] Name der betreffenden Systemvariablen.
+ #   value:  [string] Wert
+ #
+ #
+ # Rueckgabewert: [string]
+ #  Wert der Systemvariablen.
+ ##
+
+ set script {
+   var sv = dom.GetObject(name);
+
+   if (sv)
+   {
+     Write(sv.State(value));
+   }
+ }
+
+ if {[hmscript $script args] } {
+   jsonrpc_response $args(value)
+ } else {
+   jsonrpc_response -1
+ }


### PR DESCRIPTION
## What

Adds two JSON-RPC methods at `LEVEL=USER`, completing the typed system-variable API for the **string** type:

- `SysVar.createString` — `{name, init_val, internal, chnID}`
- `SysVar.setString` — `{name, value}`

Closes #129.

## Why

`string` is a first-class system-variable type — `SysVar.getAll` reports it as `STRING`, and the WebUI's own editor (`rega/pages/tabs/admin/msg/newSysVar.htm`) offers it as one of five creatable types. But unlike **bool**, **float**, and **enum** — each of which has `SysVar.create*` and `SysVar.set*` at `LEVEL=USER` — string had **no typed method at all**.

The only JSON-RPC path to create or write a string sysvar was therefore `ReGa.runScript`, which is `LEVEL=ADMIN`. As a result a normal (`USER`) account can fully manage bool/float/enum sysvars but cannot create or set a string one without full admin rights. This change removes that asymmetry.

## How

The two methods mirror the existing enum/float implementations:

- **`createstring.tcl`** mirrors `createenum.tcl`, but sets `sv.ValueType(ivtString)` and `sv.ValueSubType(istChar8859)` — the same incantation the WebUI uses in `rega/esp/system.fn`, so the variable is correctly reported as `STRING` by `SysVar.getAll`.
- **`setstring.tcl`** mirrors `setfloat.tcl`/`setbool.tcl` (`dom.GetObject(name).State(value)`).

Registered in `methods.conf` alongside their enum counterparts, both at `LEVEL=USER` — consistent with the existing `setBool`/`setFloat`/`setEnum` privilege. They expose only typed string access (no arbitrary script execution), so there is no new privilege-escalation surface.

## Changes

- `WebUI/www/api/methods/sysvar/createstring.tcl` (new)
- `WebUI/www/api/methods/sysvar/setstring.tcl` (new)
- `WebUI/www/api/methods.conf` (+2 method registrations)

## Testing

Validated by structural review against the existing enum/float/bool methods and the WebUI's string-creation path. Note: I have not been able to run this against physical CCU hardware — a maintainer round-trip test (`createString` → `getAll` shows `type: STRING` → `setString` → `getValue` → `deleteSysVarByName`) as a `USER`-level session would be the ideal confirmation before merge.
