### PR TITLE
Fix HomeMatic Script injection in hmscript_escapeString

### DIFF
--- a/WebUI/www/api/eq3/hmscript.tcl
+++ b/WebUI/www/api/eq3/hmscript.tcl
@@ -58,7 +58,12 @@ proc hmscript_runFromFile { filename {p_args -}} {
 }
 
 proc hmscript_escapeString { str } {
+  # Backslash MUST be escaped first, otherwise a backslash placed directly
+  # before a quote in user input would (after the quote is escaped to \")
+  # be read by ReGa as an escaped backslash, closing the string literal
+  # early and turning the rest of the input into executable HomeMatic Script.
   return [string map {
+    "\\" "\\\\"
     "\'" "\\\'"
     "\"" "\\\""
     "\n" "\\n"


### PR DESCRIPTION
## What

Escape the backslash character (first) in `hmscript_escapeString`.

## Why

`hmscript_escapeString` escaped the quote character but not the backslash. Because the generated HomeMatic Script `var name = "<value>";` declarations are decoded by ReGa (which performs its own backslash-escape handling), a crafted string value could terminate the literal early and have the remainder executed as live HomeMatic Script — reachable by a `LEVEL USER` JSON-RPC caller and able to run OS commands as root.

Escaping the backslash first ensures any backslash introduced by the escaping step is itself escaped, so crafted input stays inert inside the literal. This also fixes a pre-existing bug where legitimate backslashes in values (e.g. Windows-style paths) were silently dropped.

## Verification

The fix was validated by sourcing the real `hmscript_escapeString` proc, emitting the `var name = "...";` line for a breakout vector and benign values, and modelling ReGa's string-literal decoding:

- Before: the crafted value closed the literal early and the trailing tokens were parsed as executable script.
- After: the same value stays contained within the literal; benign values (including those with quotes and backslashes) round-trip correctly.

The change is ASCII-only and the file's existing ISO-8859-1 encoding is preserved.

Refs #131
